### PR TITLE
lib-ucode.c: add #define _GNU_SOURCE

### DIFF
--- a/lib-ucode.c
+++ b/lib-ucode.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <math.h>
 #include <libubox/utils.h>
 #include <libubox/usock.h>


### PR DESCRIPTION
When compiling with glibc, an error is thrown stating that vasprintf is not defined. In order to use vasprintf from glibc, the #define _GNU_SOURCE is needed.