### PR TITLE
udebug-cli: add flag not to follow log output

### DIFF
--- a/udebug-cli
+++ b/udebug-cli
@@ -17,6 +17,7 @@ const usage_message = `
 Usage: ${basename(sourcepath())} [<options>] <command> [<args>]
 
   Options:
+    -n				Do not follow logstream (poll once and return)
     -f				Ignore errors on opening rings
     -e <service list>		List of services to enable before running the command
     -d <duration>:		Only fetch data up to <duration> seconds old
@@ -151,6 +152,9 @@ while (substr(ARGV[0], 0, 1) == "-") {
 		break;
 	case 't':
 		opts.timestamp = true;
+		break;
+	case 'n':
+		opts.nofollow = true;
 		break;
 	default:
 		usage();
@@ -300,6 +304,8 @@ function stream_data(log) {
 
 	poll_data();
 	delete opts.duration;
+	if (opts.nofollow)
+		exit(1);
 	uloop.run();
 }
 


### PR DESCRIPTION
dumps the log buffer and exits

Emulates behaviour of `logread` (which is currently broken on master).